### PR TITLE
Fix handling of filenames with spaces in docker-ffmpeg-entrypoint.

### DIFF
--- a/ffmpeg/rootfs/usr/local/bin/docker-ffmpeg-entrypoint
+++ b/ffmpeg/rootfs/usr/local/bin/docker-ffmpeg-entrypoint
@@ -31,6 +31,7 @@ fi
 
 chown -R ${UID}:${GID} /etc/ffmpeg
 
+FULL_ARGS=( "$@" )
 start () {
   local pid
   if [[ -x "/usr/bin/ffmpeg" ]]; then
@@ -38,11 +39,11 @@ start () {
     if [ "${1#-}" != "$1" ]; then
       echo >&2 "📺 Starting ffmpeg with arguments \"$@\""
       # sudo --preserve-env -H -u ffmpeg -- "/usr/bin/ffmpeg" "$@" &
-      sudo --preserve-env -H -u ffmpeg -- bash -c '/usr/bin/ffmpeg "$@" || true </dev/null' ffmpeg-run "$@" &
+      sudo --preserve-env -H -u ffmpeg -- bash -c '/usr/bin/ffmpeg "$@" || true </dev/null' ffmpeg-run "${FULL_ARGS[@]}" &
       pid=$!
     else
       echo >&2 "📺 Executing ${@}"
-      sudo --preserve-env -H -u ffmpeg -- bash -c 'exec "$@" || true </dev/null' bash-run "$@" &
+      sudo --preserve-env -H -u ffmpeg -- bash -c 'exec "$@" || true </dev/null' bash-run "${FULL_ARGS[@]}" &
       pid=$!
     fi
     echo >&2 "🕴️ Waiting for process ${pid} to finish"


### PR DESCRIPTION
Modified the code to correctly recognize filenames with spaces as a single parameter instead of splitting them into multiple parameters. This resolves the issue where the original script failed to handle filenames containing spaces properly.